### PR TITLE
Fix pre req s3 region

### DIFF
--- a/infrastructure/pre_req.sh
+++ b/infrastructure/pre_req.sh
@@ -77,7 +77,12 @@ echo "Namespace: $namespace"
 if aws s3api head-bucket --bucket "${bucket_name}" --region "${aws_region}" >/dev/null 2>&1; then
     echo "S3 bucket ${bucket_name} already exists"
 else
-    if aws s3api create-bucket --bucket "${bucket_name}" --region "${aws_region}" --create-bucket-configuration LocationConstraint="${aws_region}" && \
+    # A location constraint for "us-east-1" returns an error. For "us-east-1", we omit --create-bucket-configuration
+    if [[ -n "$aws_region" ]] && [[ "$aws_region" != "us-east-1" ]]; then
+        bucket_config_arg="--create-bucket-configuration LocationConstraint=$aws_region"
+    fi
+
+    if aws s3api create-bucket --bucket "${bucket_name}" --region "${aws_region}" $bucket_config_arg && \
        aws s3api put-bucket-versioning --bucket "${bucket_name}" --versioning-configuration Status=Enabled --region "${aws_region}" && \
        aws s3api put-bucket-encryption --bucket "${bucket_name}" --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}' --region "${aws_region}"
     then


### PR DESCRIPTION
### The init script cannot create an S3 bucket in us-east-1

Fix for issue https://github.com/XgridInc/xc3/issues/50:

> The init script cannot be executed for the region us-east-1.
> It cannot create the S3 bucket because the region is invalid for the LocationConstraint.


**Changes**
- Conditionally add the LocationConstraint
- Add optional command to remove all objects and versions from the terraform-state S3 bucket.

**Why we need the change**
According to the [AWS documentation for create-bucket](https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html), we cannot specify us-east-1 as the region for the LocationConstraint.

```
--create-bucket-configuration (structure)
```
The configuration information for the bucket.

LocationConstraint -> (string)

Specifies the Region where the bucket will be created. If you don't specify a Region, the bucket is created in the US East (N. Virginia) Region (us-east-1).
Shorthand Syntax:

LocationConstraint=string
JSON Syntax:
```
{
  "LocationConstraint": "af-south-1"|"ap-east-1"|"ap-northeast-1"
  |"ap-northeast-2"|"ap-northeast-3"|"ap-south-1"|"ap-southeast-1"
  |"ap-southeast-2"|"ap-southeast-3"|"ca-central-1"|"cn-north-1"
  |"cn-northwest-1"|"EU"|"eu-central-1"|"eu-north-1"|"eu-south-1"
  |"eu-west-1"|"eu-west-2"|"eu-west-3"|"me-south-1"|"sa-east-1"
  |"us-east-2"|"us-gov-east-1"|"us-gov-west-1"|"us-west-1"|"us-west-2"
  |"ap-south-2"|"eu-south-2"
}
```